### PR TITLE
refactor: replace custom number formatters with Intl.NumberFormat

### DIFF
--- a/src/presentation/renderer/html-renderer.ts
+++ b/src/presentation/renderer/html-renderer.ts
@@ -32,7 +32,7 @@ const MONTH_NAMES = [
 const fmtCurrency = new Intl.NumberFormat("fr-FR", { currency: "EUR", style: "currency" });
 const fmtCurrencySigned = new Intl.NumberFormat("fr-FR", {
   currency: "EUR",
-  signDisplay: "always",
+  signDisplay: "exceptZero",
   style: "currency",
 });
 const fmtPercent = new Intl.NumberFormat("fr-FR", { maximumFractionDigits: 0, style: "percent" });

--- a/tests/presentation/html-renderer.test.ts
+++ b/tests/presentation/html-renderer.test.ts
@@ -200,6 +200,22 @@ describe("HtmlRenderer", () => {
       expect(html).toContain("Month-over-Month Net");
     });
 
+    it("formats non-zero net delta with sign and zero net delta without sign", () => {
+      const withZero = {
+        ...dto,
+        monthOverMonthDeltas: [
+          { groupDeltas: [], month: "2026-01", netDelta: 50 },
+          { groupDeltas: [], month: "2026-02", netDelta: 0 },
+          { groupDeltas: [], month: "2026-03", netDelta: -30 },
+        ],
+      };
+      const out = renderer.render(withZero);
+      expect(out).toContain("+50,00\u00A0€");
+      expect(out).toContain("0,00\u00A0€");
+      expect(out).not.toContain("+0,00\u00A0€");
+      expect(out).toContain("-30,00\u00A0€");
+    });
+
     it("contains monthly breakdown section", () => {
       expect(html).toContain("Monthly Summary");
     });


### PR DESCRIPTION
### Motivation
Part of: https://github.com/snutij/tally/issues/43

Hand-rolled `fmt()`, `fmtDelta()`, and `fmtPct()` helpers in `html-renderer.ts` are replaced with three module-level `Intl.NumberFormat` instances. Node 22 ships `Intl` natively — no new dependency, locale-aware formatting for free.

### Implementation
- Added `fmtCurrency`, `fmtCurrencySigned` (`signDisplay: "always"`), and `fmtPercent` at module scope in `html-renderer.ts`
- Removed `fmt()` and `fmtDelta()` entirely; updated `fmtPct()` body to delegate to `fmtPercent`
- Replaced inline `Math.round(…) + '%'` in `overshootSection` with `fmtPercent.format()`
- Output format changes to `fr-FR` locale (e.g. `750,00 €` with non-breaking space before `€`)

### Automated Tests
- Updated two hardcoded string assertions in `html-renderer.test.ts` to match `fr-FR` output (`\u00A0` before `€`)
- All 354 tests pass

### Manual Tests
- `npm run test` ✓
- `npm run lint` ✓
- `npm run fmt:check` ✓

### AI Assistance Disclosure
Implemented with Claude Code (full implementation, not just tab-completion).